### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+* text=auto
+
+/tests export-ignore
+.editorconfig export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.styleci.yml export-ignore
+.scrutinizer.yml export-ignore
+.travis.yml export-ignore
+CHANGELOG.md export-ignore
+CONTRIBUTING.md export-ignore
+phpunit.xml export-ignore


### PR DESCRIPTION
Использование `.gitattributes` позволяет при установке пакета с помощью того же `composer` не вытягивать те файлы, что не нужны в зависимости в принципе. Тесты и конфиги `CI` - они нужны для репы, но в директории `./vendor` приложения - не очень :)